### PR TITLE
Add TimeZone to #[cfg(test)] block

### DIFF
--- a/src/moonmoji.rs
+++ b/src/moonmoji.rs
@@ -2,6 +2,7 @@ use std::f64::consts::PI;
 use std::ops::{Add, Sub};
 
 use chrono::{DateTime, Duration, Utc};
+#[cfg(test)]
 use chrono::offset::TimeZone;
 use rand::random;
 


### PR DESCRIPTION
looks like you've got an unused import there parter :cowboy_hat_face: 

```
warning: unused import: `chrono::offset::TimeZone`
 --> src/moonmoji.rs:5:5
  |
5 | use chrono::offset::TimeZone;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```